### PR TITLE
Remove spurious test dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,9 +38,7 @@ flexcache = ["py.typed"]
 [project.optional-dependencies]
 test = [
     "pytest",
-    "pytest-mpl",
     "pytest-cov",
-    "pytest-subtests"
 ]
 
 [project.urls]


### PR DESCRIPTION
Remove `pytest-mpl` and `pytest-subtests` from the `test` extra because they are not actually used.

- [ ] Closes # (insert issue number) **N/A**
- [x] Executed `pre-commit run --all-files` with no errors
- [x] The change is fully covered by automated unit tests
- [ ] Added an entry to the CHANGES file **N/A – is this too trivial to record there?**
